### PR TITLE
feat: connect low pass filter to gain in audio processing graph

### DIFF
--- a/src/audio/offline-renderer.ts
+++ b/src/audio/offline-renderer.ts
@@ -133,6 +133,7 @@ const configureGraph = (
 
   pitchShiftOutput.connect(lowPass)
   lowPass.connect(delay)
+  lowPass.connect(gain)
   delay.connect(feedback)
   feedback.connect(delay)
 


### PR DESCRIPTION
This pull request includes a small change to the audio graph configuration in `src/audio/offline-renderer.ts`. The change adds a connection from the `lowPass` node directly to the `gain` node, which may affect the signal routing and output.